### PR TITLE
Change: 라떼버 검색 경력 오름차순 추가

### DIFF
--- a/src/main/java/site/hesil/latteve_spring/domains/search/service/SearchService.java
+++ b/src/main/java/site/hesil/latteve_spring/domains/search/service/SearchService.java
@@ -134,11 +134,18 @@ public class SearchService {
                                 .order(SortOrder.Desc)  // 내림차순
                         )
                 ));
-            } else if ("career".equalsIgnoreCase(sort)) {
+            } else if ("career_desc".equalsIgnoreCase(sort)) {
                 searchRequest.sort(SortOptions.of(s -> s
                         .field(f -> f
                                 .field("careerSortValue")  // 경력 기준 정렬
                                 .order(SortOrder.Desc)  // 내림차순 (경력 많은 순)
+                        )
+                ));
+            }else if ("career_asc".equalsIgnoreCase(sort)) {
+                searchRequest.sort(SortOptions.of(s -> s
+                        .field(f -> f
+                                .field("careerSortValue")  // 경력 기준 정렬
+                                .order(SortOrder.Asc)  //오름차순 (경력 적은 순)
                         )
                 ));
             }


### PR DESCRIPTION
## 📌 변경 사항
### AS-IS
라떼버 검색에 경력 내림차순(경력 많은 순) 정렬, 최신순 정렬만 있었음

### TO-BE
경력 오름차순( 경력 적은 순) 정렬 추가

## 📌 테스트
- [ ] 테스트 코드
- [ ] API 테스트
