### PR TITLE
refactor_ArgumentResolver_errorHandling

### DIFF
--- a/src/main/java/site/hesil/latteve_spring/global/error/errorcode/ErrorCode.java
+++ b/src/main/java/site/hesil/latteve_spring/global/error/errorcode/ErrorCode.java
@@ -47,6 +47,7 @@ public enum ErrorCode {
     REQUIRE_MORE_COFFEE(HttpStatus.SERVICE_UNAVAILABLE, "E90", "커피가 부족 합니다."),
     S3_IMAGE_UPLOAD_FAIL(HttpStatus.SERVICE_UNAVAILABLE, "E91", "S3 버킷에 이미지를 업로드하는데 실패하였습니다."),
     //BAD_REQUEST(HttpStatus.BAD_REQUEST, "D00", "승인되지 않은 리디렉션 URI입니다.")
+    TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "D92", "해당 작업은 로그인이 필요합니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/site/hesil/latteve_spring/global/security/ArgumentResolver/AuthMemberResolver.java
+++ b/src/main/java/site/hesil/latteve_spring/global/security/ArgumentResolver/AuthMemberResolver.java
@@ -11,6 +11,8 @@ import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
+import site.hesil.latteve_spring.global.error.errorcode.ErrorCode;
+import site.hesil.latteve_spring.global.error.exception.CustomBaseException;
 import site.hesil.latteve_spring.global.error.exception.TokenException;
 import site.hesil.latteve_spring.global.security.annotation.AuthMemberId;
 import site.hesil.latteve_spring.global.security.jwt.TokenProvider;
@@ -48,13 +50,12 @@ public class AuthMemberResolver implements HandlerMethodArgumentResolver {
                                   WebDataBinderFactory binderFactory) throws Exception {
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
         String token = extractTokenFromCookies(request);
-
+        Optional<Long> memberId = Optional.empty();
         if (token != null) {
-            Optional<Long> memberId = tokenProvider.getMemberId(token);
-            return memberId.orElseThrow(()->new TokenException("토큰 내부에서 memberId 를 찾을 수 없습니다."));
+            memberId = tokenProvider.getMemberId(token);
         }
         log.error("resolveArgument 토큰 파싱중 null 반환");
-        return null;
+        return memberId.orElseThrow(()->new CustomBaseException(ErrorCode.TOKEN_NOT_FOUND));
     }
 
     private String extractTokenFromCookies(HttpServletRequest request) {


### PR DESCRIPTION
## 📌 변경 사항
- [x] `ArgumentResolver` 예외처리를 통해 Token 에서 memberId 를 추출할 수 없는 경우 , 로그인 한 상태가 아니라고 가정하고
custom Exception 을 설정함.
- [x] 프론트엔드에서 해당 custom Exception 의 메세지를 활용해 모달창 출력

* [내용 정리](https://share.note.sx/ir12vgu9#HLq3hvaXW0qUYA/+Rl7rul3lEvocHZrBpmwj+1vV6vc)

