### PR TITLE
프로젝트 상세 페이지 지원, 회고 조회

### DIFF
--- a/src/main/java/site/hesil/latteve_spring/domains/project/controller/ProjectController.java
+++ b/src/main/java/site/hesil/latteve_spring/domains/project/controller/ProjectController.java
@@ -1,13 +1,11 @@
 package site.hesil.latteve_spring.domains.project.controller;
 
-import com.amazonaws.Response;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import site.hesil.latteve_spring.domains.project.domain.Project;
 import site.hesil.latteve_spring.domains.project.dto.project.request.ProjectApplyRequest;
-import lombok.extern.log4j.Log4j2;
 import site.hesil.latteve_spring.domains.project.dto.project.response.ProjectDetailResponse;
 import site.hesil.latteve_spring.domains.project.dto.request.projectSave.ProjectSaveRequest;
 import site.hesil.latteve_spring.domains.project.dto.response.ApplicationResponse;
@@ -47,9 +45,9 @@ public class ProjectController {
 
     // 프로젝트 지원
     @PostMapping("/{projectId}/applications")
-    public ResponseEntity<Void> applyProject(@PathVariable Long projectId, @RequestBody ProjectApplyRequest projectApplyRequest) {
+    public ResponseEntity<Void> applyProject(@PathVariable Long projectId, @AuthMemberId Long memberId, @RequestBody ProjectApplyRequest projectApplyRequest) {
 
-        projectService.applyProject(projectId, projectApplyRequest.memberId(), projectApplyRequest.jobId());
+        projectService.applyProject(projectId, memberId, projectApplyRequest.jobId());
 
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }

--- a/src/main/java/site/hesil/latteve_spring/domains/project/controller/ProjectController.java
+++ b/src/main/java/site/hesil/latteve_spring/domains/project/controller/ProjectController.java
@@ -2,20 +2,20 @@ package site.hesil.latteve_spring.domains.project.controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-import site.hesil.latteve_spring.domains.project.dto.project.request.ProjectApplyRequest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 import site.hesil.latteve_spring.domains.member.controller.MemberController;
+import site.hesil.latteve_spring.domains.project.dto.project.request.ProjectApplyRequest;
 import site.hesil.latteve_spring.domains.project.dto.project.response.ProjectCardResponse;
 import site.hesil.latteve_spring.domains.project.dto.project.response.ProjectDetailResponse;
 import site.hesil.latteve_spring.domains.project.dto.request.projectSave.ProjectSaveRequest;
 import site.hesil.latteve_spring.domains.project.dto.response.ApplicationResponse;
+import site.hesil.latteve_spring.domains.project.dto.response.RetrospectiveResponse;
 import site.hesil.latteve_spring.domains.project.service.ProjectService;
-
 import site.hesil.latteve_spring.global.security.annotation.AuthMemberId;
 
 import java.util.List;
@@ -91,5 +91,14 @@ public class ProjectController {
         Pageable pageable = PageRequest.of(page, size);
         Page<ProjectCardResponse> projectPage = projectService.getProjectsByMemberAndLike(memberId, pageable);
         return ResponseEntity.ok(projectPage);
+    }
+
+    // 회고 조회
+    @GetMapping("/{projectId}/retrospectives")
+    public ResponseEntity<RetrospectiveResponse> getRetrospective(@PathVariable Long projectId,
+                                                                  @RequestParam Long memberId,
+                                                                  @RequestParam int week) {
+
+        return ResponseEntity.ok(projectService.getRetrospective(projectId, memberId, week));
     }
 }

--- a/src/main/java/site/hesil/latteve_spring/domains/project/dto/project/request/ProjectApplyRequest.java
+++ b/src/main/java/site/hesil/latteve_spring/domains/project/dto/project/request/ProjectApplyRequest.java
@@ -14,4 +14,4 @@ import lombok.Builder;
  * 2024-09-01        JooYoon       최초 생성
  */
 @Builder
-public record ProjectApplyRequest(Long memberId, Long jobId) {}
+public record ProjectApplyRequest(Long jobId) {}

--- a/src/main/java/site/hesil/latteve_spring/domains/project/dto/response/RetrospectiveResponse.java
+++ b/src/main/java/site/hesil/latteve_spring/domains/project/dto/response/RetrospectiveResponse.java
@@ -1,0 +1,21 @@
+package site.hesil.latteve_spring.domains.project.dto.response;
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+/**
+ * packageName    : site.hesil.latteve_spring.domains.project.dto.response
+ * fileName       : RetrospectiveResponse
+ * author         : JooYoon
+ * date           : 2024-09-05
+ * description    :
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 2024-09-05        JooYoon       최초 생성
+ */
+
+@Builder
+public record RetrospectiveResponse(String title, String content, LocalDateTime createdAt, LocalDateTime updatedAt) {
+}

--- a/src/main/java/site/hesil/latteve_spring/domains/project/repository/project/custom/ProjectRepositoryCustom.java
+++ b/src/main/java/site/hesil/latteve_spring/domains/project/repository/project/custom/ProjectRepositoryCustom.java
@@ -4,8 +4,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import site.hesil.latteve_spring.domains.project.domain.Project;
 import site.hesil.latteve_spring.domains.project.dto.project.response.ProjectDetailResponse;
+import site.hesil.latteve_spring.domains.project.dto.response.RetrospectiveResponse;
 
-import java.util.List;
 import java.util.Optional;
 
 /**
@@ -31,5 +31,5 @@ public interface ProjectRepositoryCustom {
 
     Page<Project> findProjectsByMemberIdAndStatus(Long memberId, int status, Pageable pageable);
 
-
+    Optional<RetrospectiveResponse> getRetrospective(Long projectId, Long memberId, int week);
 }

--- a/src/main/java/site/hesil/latteve_spring/domains/project/repository/project/custom/ProjectRepositoryImpl.java
+++ b/src/main/java/site/hesil/latteve_spring/domains/project/repository/project/custom/ProjectRepositoryImpl.java
@@ -15,7 +15,9 @@ import site.hesil.latteve_spring.domains.project.domain.QProject;
 import site.hesil.latteve_spring.domains.project.domain.projectMember.QProjectMember;
 import site.hesil.latteve_spring.domains.project.domain.recruitment.QRecruitment;
 import site.hesil.latteve_spring.domains.project.dto.project.response.ProjectDetailResponse;
+import site.hesil.latteve_spring.domains.project.dto.response.RetrospectiveResponse;
 import site.hesil.latteve_spring.domains.projectStack.domain.QProjectStack;
+import site.hesil.latteve_spring.domains.retrospective.domain.QRetrospective;
 import site.hesil.latteve_spring.domains.techStack.domain.QTechStack;
 import site.hesil.latteve_spring.global.error.errorcode.ErrorCode;
 import site.hesil.latteve_spring.global.error.exception.CustomBaseException;
@@ -280,5 +282,30 @@ public class ProjectRepositoryImpl implements ProjectRepositoryCustom {
 
 
         return count != null ? count.intValue() : 0;
+    }
+
+    @Override
+    public Optional<RetrospectiveResponse> getRetrospective(Long projectId, Long memberId, int week) {
+        QRetrospective retrospective = QRetrospective.retrospective;
+
+        Tuple retrospectiveInto = queryFactory.select(
+                retrospective.title,
+                retrospective.content,
+                retrospective.createdAt,
+                retrospective.updatedAt)
+                .from(retrospective)
+                .where(retrospective.project.projectId.eq(projectId)
+                        .and(retrospective.member.memberId.eq(memberId))
+                        .and(retrospective.week.eq(week)))
+                .fetchOne();
+
+        if (retrospectiveInto == null) throw new CustomBaseException(ErrorCode.NOT_FOUND);
+
+        return Optional.ofNullable(RetrospectiveResponse.builder()
+                .title(retrospectiveInto.get(retrospective.title))
+                .content(retrospectiveInto.get(retrospective.content))
+                .createdAt(retrospectiveInto.get(retrospective.createdAt))
+                .updatedAt(retrospectiveInto.get(retrospective.updatedAt))
+                .build());
     }
 }

--- a/src/main/java/site/hesil/latteve_spring/domains/project/service/ProjectService.java
+++ b/src/main/java/site/hesil/latteve_spring/domains/project/service/ProjectService.java
@@ -4,11 +4,9 @@ package site.hesil.latteve_spring.domains.project.service;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
-
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import site.hesil.latteve_spring.domains.alarm.domain.Alarm;
@@ -24,13 +22,13 @@ import site.hesil.latteve_spring.domains.project.dto.project.response.ProjectCar
 import site.hesil.latteve_spring.domains.project.dto.project.response.ProjectDetailResponse;
 import site.hesil.latteve_spring.domains.project.dto.request.projectSave.ProjectSaveRequest;
 import site.hesil.latteve_spring.domains.project.dto.response.ApplicationResponse;
+import site.hesil.latteve_spring.domains.project.dto.response.RetrospectiveResponse;
 import site.hesil.latteve_spring.domains.project.repository.project.ProjectRepository;
 import site.hesil.latteve_spring.domains.project.repository.projectLike.ProjectLikeRepository;
 import site.hesil.latteve_spring.domains.project.repository.projectMember.ProjectMemberRepository;
 import site.hesil.latteve_spring.domains.project.repository.recruitment.RecruitmentRepository;
 import site.hesil.latteve_spring.domains.projectStack.domain.ProjectStack;
 import site.hesil.latteve_spring.domains.projectStack.repository.ProjectStackRepository;
-
 import site.hesil.latteve_spring.domains.techStack.domain.TechStack;
 import site.hesil.latteve_spring.domains.techStack.repository.TechStackRepository;
 import site.hesil.latteve_spring.global.error.errorcode.ErrorCode;
@@ -197,6 +195,11 @@ public class ProjectService {
 
     }
 
+    // 회고 조회
+    public RetrospectiveResponse getRetrospective(Long projectId, Long memberId, int week) {
 
+        return projectRepository.getRetrospective(projectId, memberId, week)
+                .orElseThrow(() -> new CustomBaseException(ErrorCode.NOT_FOUND));
+    }
 
 }

--- a/src/main/java/site/hesil/latteve_spring/domains/project/service/ProjectService.java
+++ b/src/main/java/site/hesil/latteve_spring/domains/project/service/ProjectService.java
@@ -23,7 +23,6 @@ import site.hesil.latteve_spring.domains.project.repository.recruitment.Recruitm
 import site.hesil.latteve_spring.domains.projectStack.repository.ProjectStackRepository;
 import site.hesil.latteve_spring.global.error.errorcode.ErrorCode;
 import site.hesil.latteve_spring.global.error.exception.CustomBaseException;
-import site.hesil.latteve_spring.global.security.jwt.TokenProvider;
 
 import java.util.List;
 
@@ -78,7 +77,7 @@ public class ProjectService {
                 }).toList();
     }
     
-  // 프로젝트 지원
+    // 프로젝트 지원
     public void applyProject(Long projectId, Long memberId, Long jobId) {
         Project project = projectRepository.findById(projectId)
                 .orElseThrow(() -> new EntityNotFoundException("Project not found"));


### PR DESCRIPTION
## 📌 변경 사항
### AS-IS


### TO-BE
- 기존 memberId를 request body에 담아 보내는 것에서 @AuthMemberId 어노테이션 이용해서 가져오는 것으로 변경
- 프로젝트 회고 조회 api 완성

## 📌 테스트
- [ ] 테스트 코드
- [x] API 테스트
