### PR TITLE
Fix: 프로젝트 신규순 조회 - 모집중인 프로젝트만 나오는 에러 해결

### DIFF
--- a/src/main/java/site/hesil/latteve_spring/domains/project/controller/ProjectController.java
+++ b/src/main/java/site/hesil/latteve_spring/domains/project/controller/ProjectController.java
@@ -157,12 +157,5 @@ public class ProjectController {
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
-//    // 인기 프로젝트 조회
-//    @GetMapping("/popular")
-//    public ResponseEntity<Page<PopularProjectResponse>> getPopularProjectList(@RequestParam(defaultValue = "0") int page,
-//                                                                              @RequestParam(defaultValue = "4") int size){
-//
-//        return ResponseEntity.ok(projectService.getProjectsByScore());
-//    }
 
 }

--- a/src/main/java/site/hesil/latteve_spring/domains/project/repository/project/ProjectRepository.java
+++ b/src/main/java/site/hesil/latteve_spring/domains/project/repository/project/ProjectRepository.java
@@ -43,6 +43,7 @@ public interface ProjectRepository extends JpaRepository<Project, Long>, Project
                                                         Pageable pageable);
 
     // 신규순으로 조회하는 쿼리
+    @Query("SELECT p FROM Project p WHERE p.status <> 2 ORDER BY p.createdAt DESC")
     Page<Project> findAllByStatusOrderByCreatedAtDesc(int status, Pageable pageable);
 
 

--- a/src/main/java/site/hesil/latteve_spring/domains/project/service/ProjectService.java
+++ b/src/main/java/site/hesil/latteve_spring/domains/project/service/ProjectService.java
@@ -229,10 +229,10 @@ public class ProjectService {
 
     }
 
-    // 신규순으로 조회
+    // 신규순으로 조회 (모집중, 진행중)
     public Page<ProjectCardResponse> getProjectsOrderedByCreatedAt(Pageable pageable,Long memberId) {
 
-        Page<Project> projectPage = projectRepository.findAllByStatusOrderByCreatedAtDesc(1, pageable);
+        Page<Project> projectPage = projectRepository.findAllByStatusOrderByCreatedAtDesc(0, pageable);
         List<ProjectCardResponse> projectCardList = getProjectCardList(projectPage.getContent(),memberId);
         return new PageImpl<>(projectCardList, pageable, projectPage.getTotalElements());
     }


### PR DESCRIPTION
## 📌 변경 사항
### AS-IS


### TO-BE
projectRepository에서 프로젝트 조회하는 쿼리에서 status가 2만 아니면 신규순으로 반환하도록 함

## 📌 테스트
- [ ] 테스트 코드
- [ ] API 테스트
