### PR TITLE
Add: Alarm 위한 DTO 생성

### DIFF
--- a/src/main/java/site/hesil/latteve_spring/domains/alarm/dto/ProjectApplicationAlarm.java
+++ b/src/main/java/site/hesil/latteve_spring/domains/alarm/dto/ProjectApplicationAlarm.java
@@ -1,0 +1,19 @@
+package site.hesil.latteve_spring.domains.alarm.dto;
+
+import lombok.Builder;
+
+/**
+ * packageName    : site.hesil.latteve_spring.domains.alarm.dto
+ * fileName       : ProjectApplicationAlarm
+ * author         : JooYoon
+ * date           : 2024-09-08
+ * description    :
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 2024-09-08        JooYoon       최초 생성
+ */
+
+// 지원 알람: 프로젝트명, 멤버닉네임, 직무명, 프로젝트리더아이디
+@Builder
+public record ProjectApplicationAlarm(String projectName, String nickname, String jobName, Long projectLeaderId) {}

--- a/src/main/java/site/hesil/latteve_spring/domains/alarm/dto/ProjectApprovalResultAlarm.java
+++ b/src/main/java/site/hesil/latteve_spring/domains/alarm/dto/ProjectApprovalResultAlarm.java
@@ -1,0 +1,19 @@
+package site.hesil.latteve_spring.domains.alarm.dto;
+
+import lombok.Builder;
+
+/**
+ * packageName    : site.hesil.latteve_spring.domains.alarm.dto
+ * fileName       : ProjectApprovalResultAlarm
+ * author         : JooYoon
+ * date           : 2024-09-08
+ * description    :
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 2024-09-08        JooYoon       최초 생성
+ */
+
+// 프로젝트 승인 및 거절 알람: 프로젝트명, 승인여부, 받는멤버아이디
+@Builder
+public record ProjectApprovalResultAlarm(String projectName, int acceptStatus, Long receiverMemberId) {}


### PR DESCRIPTION
## 📌 변경 사항
### AS-IS


### TO-BE
- 프로젝트 지원 알람을 위한 ProjectApplicationAlarm record 생성
- 프로젝트 승인/거절 알람을 위한 ProjectApprovalResultAlarm record 생성

## 📌 테스트
- [ ] 테스트 코드
- [ ] API 테스트
