### PR TITLE
회고 등록 기능 추가 및 Entity 메서드명 변경

### DIFF
--- a/src/main/java/site/hesil/latteve_spring/domains/alarm/domain/Alarm.java
+++ b/src/main/java/site/hesil/latteve_spring/domains/alarm/domain/Alarm.java
@@ -55,7 +55,7 @@ public class Alarm {
         this.isRead = false;
     }
 
-    public static Alarm createAlarm(Project project, Member member, Job job, Integer type) {
+    public static Alarm of(Project project, Member member, Job job, Integer type) {
         return new Alarm(project, member, job, type);
     }
 }

--- a/src/main/java/site/hesil/latteve_spring/domains/project/controller/ProjectController.java
+++ b/src/main/java/site/hesil/latteve_spring/domains/project/controller/ProjectController.java
@@ -16,6 +16,7 @@ import site.hesil.latteve_spring.domains.project.dto.request.projectSave.Project
 import site.hesil.latteve_spring.domains.project.dto.response.ApplicationResponse;
 import site.hesil.latteve_spring.domains.project.dto.response.RetrospectiveResponse;
 import site.hesil.latteve_spring.domains.project.service.ProjectService;
+import site.hesil.latteve_spring.domains.retrospective.dto.CreateRetrospectiveRequest;
 import site.hesil.latteve_spring.global.security.annotation.AuthMemberId;
 
 import java.util.List;
@@ -101,4 +102,15 @@ public class ProjectController {
 
         return ResponseEntity.ok(projectService.getRetrospective(projectId, memberId, week));
     }
+
+    // 프로젝트 회고 등록
+    @PostMapping("/{projectId}/retrospectives")
+    public ResponseEntity<Void> saveRetrospective(@PathVariable Long projectId,
+                                                  @AuthMemberId Long memberId,
+                                                  @RequestBody CreateRetrospectiveRequest createRetrospectiveRequest) {
+
+        projectService.saveRetrospective(projectId, memberId, createRetrospectiveRequest);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
 }

--- a/src/main/java/site/hesil/latteve_spring/domains/project/domain/projectMember/ProjectMember.java
+++ b/src/main/java/site/hesil/latteve_spring/domains/project/domain/projectMember/ProjectMember.java
@@ -58,7 +58,7 @@ public class ProjectMember {
         this.acceptStatus = 2;
     }
 
-    public static ProjectMember createMember(Project project, Member member, Job job) {
+    public static ProjectMember of(Project project, Member member, Job job) {
         return new ProjectMember(project, member, job);
     }
 }

--- a/src/main/java/site/hesil/latteve_spring/domains/project/repository/projectMember/ProjectMemberRepository.java
+++ b/src/main/java/site/hesil/latteve_spring/domains/project/repository/projectMember/ProjectMemberRepository.java
@@ -9,6 +9,7 @@ import site.hesil.latteve_spring.domains.project.domain.projectMember.ProjectMem
 import site.hesil.latteve_spring.domains.project.domain.projectMember.ProjectMemberId;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * packageName    : site.hesil.latteve_spring.domains.project.repository
@@ -41,5 +42,8 @@ public interface ProjectMemberRepository extends JpaRepository<ProjectMember, Pr
     @Modifying
     @Query(value = "INSERT INTO project_member (project_id, member_id, job_id, is_leader, accept_status) VALUES (:projectId, :memberId, 1, 1, 1)", nativeQuery = true)
     void registerProjectLeader(@Param("projectId") Long projectId, @Param("memberId") Long memberId);
+
+    @Query("SELECT pm FROM ProjectMember pm WHERE pm.projectMemberId.projectId = :projectId AND pm.projectMemberId.memberId = :memberId")
+    Optional<ProjectMember> findByProjectIdAndProjectMemberId(@Param("projectId") Long projectId, @Param("memberId") Long memberId);
 }
 

--- a/src/main/java/site/hesil/latteve_spring/domains/project/service/ProjectService.java
+++ b/src/main/java/site/hesil/latteve_spring/domains/project/service/ProjectService.java
@@ -108,7 +108,7 @@ public class ProjectService {
         projectMemberRepository.save(projectMember);
 
         // alarm 테이블에 데이터 삽입
-        Alarm alarm = Alarm.createAlarm(project, member, job, 0);
+        Alarm alarm = Alarm.of(project, member, job, 0);
 
         alarmRepository.save(alarm);
 

--- a/src/main/java/site/hesil/latteve_spring/domains/project/service/ProjectService.java
+++ b/src/main/java/site/hesil/latteve_spring/domains/project/service/ProjectService.java
@@ -29,6 +29,9 @@ import site.hesil.latteve_spring.domains.project.repository.projectMember.Projec
 import site.hesil.latteve_spring.domains.project.repository.recruitment.RecruitmentRepository;
 import site.hesil.latteve_spring.domains.projectStack.domain.ProjectStack;
 import site.hesil.latteve_spring.domains.projectStack.repository.ProjectStackRepository;
+import site.hesil.latteve_spring.domains.retrospective.domain.Retrospective;
+import site.hesil.latteve_spring.domains.retrospective.dto.CreateRetrospectiveRequest;
+import site.hesil.latteve_spring.domains.retrospective.repository.RetrospectiveRepository;
 import site.hesil.latteve_spring.domains.techStack.domain.TechStack;
 import site.hesil.latteve_spring.domains.techStack.repository.TechStackRepository;
 import site.hesil.latteve_spring.global.error.errorcode.ErrorCode;
@@ -66,6 +69,7 @@ public class ProjectService {
     private final MemberStackRepository memberStackRepository;
     private final TechStackRepository techStackRepository;
     private final ProjectLikeRepository projectLikeRepository;
+    private final RetrospectiveRepository retrospectiveRepository;
 
     // 프로젝트 상세 페이지 정보
     public ProjectDetailResponse getProjectDetail(Long projectId) {
@@ -202,4 +206,27 @@ public class ProjectService {
                 .orElseThrow(() -> new CustomBaseException(ErrorCode.NOT_FOUND));
     }
 
+    // 프로젝트 회고 등록
+    public void saveRetrospective(Long projectId, Long memberId, CreateRetrospectiveRequest createRetrospectiveRequest) {
+
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new CustomBaseException(ErrorCode.NOT_FOUND));
+        log.debug("project: {}", project);
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomBaseException(ErrorCode.NOT_FOUND));
+        log.debug("member: {}", member);
+
+        ProjectMember projectMember = projectMemberRepository.findByProjectIdAndProjectMemberId(projectId, memberId)
+                .orElseThrow(() -> new CustomBaseException(ErrorCode.NOT_FOUND));
+        log.debug("projectMember: {}", projectMember);
+
+        Job job = projectMember.getJob();
+
+        Retrospective retrospective = Retrospective.of(project, member, job, createRetrospectiveRequest.title(),
+                createRetrospectiveRequest.content(), createRetrospectiveRequest.week());
+        log.debug("retrospective: {}", retrospective);
+
+        retrospectiveRepository.save(retrospective);
+    }
 }

--- a/src/main/java/site/hesil/latteve_spring/domains/project/service/ProjectService.java
+++ b/src/main/java/site/hesil/latteve_spring/domains/project/service/ProjectService.java
@@ -103,7 +103,7 @@ public class ProjectService {
                 .orElseThrow(() -> new EntityNotFoundException("Job not found"));
 
         // project_member 테이블에 데이터 삽입
-        ProjectMember projectMember = ProjectMember.createMember(project, member, job);
+        ProjectMember projectMember = ProjectMember.of(project, member, job);
 
         projectMemberRepository.save(projectMember);
 

--- a/src/main/java/site/hesil/latteve_spring/domains/retrospective/domain/Retrospective.java
+++ b/src/main/java/site/hesil/latteve_spring/domains/retrospective/domain/Retrospective.java
@@ -45,4 +45,17 @@ public class Retrospective extends BaseTimeEntity {
     private String title;
     private String content;
     private int week;
+
+    private Retrospective(Project project, Member member, Job job, String title, String content, int week) {
+        this.project = project;
+        this.member = member;
+        this.job = job;
+        this.title = title;
+        this.content = content;
+        this.week = week;
+    }
+
+    public static Retrospective of(Project project, Member member, Job job, String title, String content, int week) {
+        return new Retrospective(project, member, job, title, content, week);
+    }
 }

--- a/src/main/java/site/hesil/latteve_spring/domains/retrospective/dto/CreateRetrospectiveRequest.java
+++ b/src/main/java/site/hesil/latteve_spring/domains/retrospective/dto/CreateRetrospectiveRequest.java
@@ -1,0 +1,15 @@
+package site.hesil.latteve_spring.domains.retrospective.dto;
+
+/**
+ * packageName    : site.hesil.latteve_spring.domains.retrospective.dto
+ * fileName       : CreateRetrospectiveRequest
+ * author         : JooYoon
+ * date           : 2024-09-06
+ * description    :
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 2024-09-06        JooYoon       최초 생성
+ */
+public record CreateRetrospectiveRequest(int week, String title, String content) {
+}

--- a/src/main/java/site/hesil/latteve_spring/domains/retrospective/dto/UpdateRetrospectiveRequest.java
+++ b/src/main/java/site/hesil/latteve_spring/domains/retrospective/dto/UpdateRetrospectiveRequest.java
@@ -1,0 +1,15 @@
+package site.hesil.latteve_spring.domains.retrospective.dto;
+
+/**
+ * packageName    : site.hesil.latteve_spring.domains.retrospective.dto
+ * fileName       : UpdateRetrospectiveRequest
+ * author         : JooYoon
+ * date           : 2024-09-06
+ * description    :
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 2024-09-06        JooYoon       최초 생성
+ */
+public record UpdateRetrospectiveRequest(String title, String content) {
+}

--- a/src/main/java/site/hesil/latteve_spring/domains/retrospective/repository/RetrospectiveRepository.java
+++ b/src/main/java/site/hesil/latteve_spring/domains/retrospective/repository/RetrospectiveRepository.java
@@ -1,0 +1,18 @@
+package site.hesil.latteve_spring.domains.retrospective.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import site.hesil.latteve_spring.domains.retrospective.domain.Retrospective;
+
+/**
+ * packageName    : site.hesil.latteve_spring.domains.retrospective.repository
+ * fileName       : RetrospectiveRepository
+ * author         : JooYoon
+ * date           : 2024-09-06
+ * description    :
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 2024-09-06        JooYoon       최초 생성
+ */
+public interface RetrospectiveRepository extends JpaRepository<Retrospective, Long> {
+}


### PR DESCRIPTION
## 📌 변경 사항
### AS-IS


### TO-BE
- 회고 등록 api 완성
- 정적 팩토리 메서드 패턴 명명 규칙에 따라 Alarm/ProjectMember Entity의 createAlarm()/createMember() 메서드명을 of로 변경

## 📌 테스트
- [ ] 테스트 코드
- [ ] API 테스트
