### PR TITLE
change/자잘한 버그 수정

### DIFF
--- a/src/main/java/site/hesil/latteve_spring/domains/alarm/dto/ProjectApprovalResultAlarm.java
+++ b/src/main/java/site/hesil/latteve_spring/domains/alarm/dto/ProjectApprovalResultAlarm.java
@@ -1,6 +1,7 @@
 package site.hesil.latteve_spring.domains.alarm.dto;
 
 import lombok.Builder;
+import site.hesil.latteve_spring.domains.project.domain.projectMember.ProjectMember;
 
 /**
  * packageName    : site.hesil.latteve_spring.domains.alarm.dto
@@ -16,4 +17,12 @@ import lombok.Builder;
 
 // 프로젝트 승인 및 거절 알람: 프로젝트명, 승인여부, 받는멤버아이디
 @Builder
-public record ProjectApprovalResultAlarm(String projectName, int acceptStatus, Long receiverMemberId) {}
+public record ProjectApprovalResultAlarm(String projectName, int acceptStatus, Long receiverMemberId) {
+    public static ProjectApprovalResultAlarm from (ProjectMember projectMember) {
+        return ProjectApprovalResultAlarm.builder()
+                .projectName(projectMember.getProject().getName())
+                .acceptStatus(projectMember.getAcceptStatus())
+                .receiverMemberId(projectMember.getMember().getMemberId())
+                .build();
+    }
+}

--- a/src/main/java/site/hesil/latteve_spring/domains/project/dto/project/request/UpdateAcceptStatusRequest.java
+++ b/src/main/java/site/hesil/latteve_spring/domains/project/dto/project/request/UpdateAcceptStatusRequest.java
@@ -13,6 +13,7 @@ package site.hesil.latteve_spring.domains.project.dto.project.request;
 
 public record UpdateAcceptStatusRequest(
         long projectId,
+        int jobId,
         long memberId,
         int acceptStatus
 ) {

--- a/src/main/java/site/hesil/latteve_spring/domains/project/dto/project/response/ProjectMemberResponse.java
+++ b/src/main/java/site/hesil/latteve_spring/domains/project/dto/project/response/ProjectMemberResponse.java
@@ -15,6 +15,7 @@ import java.util.List;
  * 2024-09-08        Yeong-Huns       최초 생성
  */
 public record ProjectMemberResponse(
+        long jobId,
         String jobName,
         long projectMemberId,
         String projectMemberNickname,

--- a/src/main/java/site/hesil/latteve_spring/domains/project/dto/response/ApplicationResponse.java
+++ b/src/main/java/site/hesil/latteve_spring/domains/project/dto/response/ApplicationResponse.java
@@ -20,6 +20,7 @@ import java.util.List;
  */
 @Builder
 public record ApplicationResponse(
+        long jobId,
         String jobName,
         long projectMemberId,
         String projectMemberNickname,
@@ -31,6 +32,7 @@ public record ApplicationResponse(
 ) {
     public static ApplicationResponse of(ProjectMemberResponse projectMemberResponse, List<MemberStackResponse> techStack) {
         return ApplicationResponse.builder()
+                .jobId(projectMemberResponse.jobId())
                 .projectMemberId(projectMemberResponse.projectMemberId())
                 .projectMemberNickname(projectMemberResponse.projectMemberNickname())
                 .projectMemberGitHub(projectMemberResponse.projectMemberGitHub())

--- a/src/main/java/site/hesil/latteve_spring/domains/project/repository/projectMember/ProjectMemberRepository.java
+++ b/src/main/java/site/hesil/latteve_spring/domains/project/repository/projectMember/ProjectMemberRepository.java
@@ -49,6 +49,7 @@ public interface ProjectMemberRepository extends JpaRepository<ProjectMember, Pr
 
     @Query("""
                 SELECT new site.hesil.latteve_spring.domains.project.dto.project.response.ProjectMemberResponse(
+                    pm.job.jobId,
                     pm.job.name,
                     pm.member.memberId,
                     pm.member.nickname,
@@ -63,7 +64,7 @@ public interface ProjectMemberRepository extends JpaRepository<ProjectMember, Pr
                     (SELECT COUNT(p)
                      FROM ProjectMember pm3
                      JOIN pm3.project p
-                     WHERE pm3.member.memberId = pm.member.memberId 
+                     WHERE pm3.member.memberId = pm.member.memberId
                        AND p.status = 2
                        AND pm3.acceptStatus = 1)
                 )
@@ -76,8 +77,14 @@ public interface ProjectMemberRepository extends JpaRepository<ProjectMember, Pr
     @Query("SELECT pm.isLeader FROM ProjectMember pm WHERE pm.project.projectId = :projectId AND pm.member.memberId = :memberId")
     boolean isLeader(@Param("projectId") Long projectId, @Param("memberId") Long memberId);
 
+    @Query("SELECT COUNT(pm) > 0 FROM ProjectMember pm WHERE pm.project.projectId = :projectId AND pm.member.memberId = :memberId AND (pm.acceptStatus = 1 OR pm.acceptStatus = 2)")
+    boolean isApplication(@Param("projectId") Long projectId, @Param("memberId") Long memberId);
+
     @Query("SELECT pm FROM ProjectMember pm WHERE pm.project.projectId = :projectId AND pm.member.memberId = :memberId")
-    Optional<ProjectMember> findByProjectIdAndMemberId(@Param("projectId") Long projectId, @Param("memberId") Long memberId);
+    Optional<ProjectMember> findByProjectIdAndMemberId(@Param("projectId") Long projectId,  @Param("memberId") Long memberId);
+
+    @Query("SELECT pm FROM ProjectMember pm WHERE pm.project.projectId = :projectId AND pm.member.memberId = :memberId AND pm.job.jobId = :jobId AND pm.acceptStatus = 2")
+    Optional<ProjectMember> findByProjectIdAndMemberIdAndJobId(@Param("projectId") Long projectId, @Param("jobId") int jobId , @Param("memberId") Long memberId);
 
     @Modifying
     @Query("UPDATE ProjectMember pm SET pm.acceptStatus = 0 WHERE pm.project.projectId = :projectId AND pm.acceptStatus = 2")

--- a/src/main/java/site/hesil/latteve_spring/domains/project/service/ProjectService.java
+++ b/src/main/java/site/hesil/latteve_spring/domains/project/service/ProjectService.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import site.hesil.latteve_spring.domains.alarm.domain.Alarm;
 import site.hesil.latteve_spring.domains.alarm.dto.ProjectApplicationAlarm;
+import site.hesil.latteve_spring.domains.alarm.dto.ProjectApprovalResultAlarm;
 import site.hesil.latteve_spring.domains.alarm.repository.AlarmRepository;
 import site.hesil.latteve_spring.domains.job.domain.Job;
 import site.hesil.latteve_spring.domains.job.repository.JobRepository;
@@ -72,6 +73,7 @@ import java.util.stream.Collectors;
  * 2024-09-08        Heeseon       좋아요 여부 확인 추가
  * 2024-09-08        Yeong-Huns    좋아요, 좋아요 취소
  * 2024-09-11        Yeong-Huns    getApplicationsByProjectId 쿼리 성능개선
+ * 2024-09-11        Yeong-Huns    applyProject 이미 지원중인 인원인지 검증로직 추가
  */
 @Slf4j
 @Service
@@ -152,10 +154,11 @@ public class ProjectService {
     public void updateAcceptStatus(UpdateAcceptStatusRequest updateAcceptStatusRequest, Long memberId){
         boolean isLeader = projectMemberRepository.isLeader(updateAcceptStatusRequest.projectId(), memberId);
         if(!isLeader) throw new CustomBaseException(ErrorCode.UNAUTHORIZED_ACTION);
-        ProjectMember projectMember = projectMemberRepository.findByProjectIdAndMemberId(updateAcceptStatusRequest.projectId(), updateAcceptStatusRequest.memberId())
+        ProjectMember projectMember = projectMemberRepository.findByProjectIdAndMemberIdAndJobId(updateAcceptStatusRequest.projectId(), updateAcceptStatusRequest.jobId(), updateAcceptStatusRequest.memberId())
                 .orElseThrow(()-> new NotFoundException("프로젝트 승인/거절 : 해당 유저를 찾을수 없습니다!"));
         projectMember.updateAcceptStatus(updateAcceptStatusRequest.acceptStatus()); // 변경감지 저장
-        log.info(projectMember.toString());
+        mqSender.sendMessage(MQExchange.ALARM.getExchange(), MQRouting.APPROVAL_RESULT.getRouting(), ProjectApprovalResultAlarm.from(projectMember));
+        //log.info(projectMember.toString());
     }
 
     @Transactional
@@ -171,6 +174,9 @@ public class ProjectService {
     // 프로젝트 지원
     @Transactional
     public void applyProject(Long projectId, Long memberId, Long jobId) {
+        boolean isApplication = projectMemberRepository.isApplication(projectId, memberId);
+        if(isApplication) throw new CustomBaseException(ErrorCode.ALREADY_APPLICATION);
+
         Project project = projectRepository.findById(projectId)
                 .orElseThrow(() -> new EntityNotFoundException("Project not found"));
 

--- a/src/main/java/site/hesil/latteve_spring/global/error/errorcode/ErrorCode.java
+++ b/src/main/java/site/hesil/latteve_spring/global/error/errorcode/ErrorCode.java
@@ -28,7 +28,7 @@ public enum ErrorCode {
     TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED,"D98", "토큰이 만료되었습니다."),
     ILLEGAL_REGISTRATION_ID(HttpStatus.NOT_ACCEPTABLE, "D99","illegal registration id"),
     INVALID_JWT_SIGNATURE(HttpStatus.UNAUTHORIZED,"D89","잘못된 JWT 시그니처입니다."),
-
+    ALREADY_APPLICATION(HttpStatus.UNAUTHORIZED, "D88", "이미 지원중입니다."),
     // User
     ALREADY_EXIST(HttpStatus.BAD_REQUEST, "D94", "이미 존재하는 사용자입니다."),
 


### PR DESCRIPTION
## 📌 변경 사항
- [x]  이미 프로젝트 지원중이라면, 다른 직무로도 지원할 수 없어야 한다. - yh
- [x]  이미 지원이 거절된 이력이 존재하여도, 새로운 지원요청을 거절할 수 있어야한다. - yh
- [x]  프로젝트 지원 실패(오류발생)시 모달창이 안뜨는 문제 -yh
    - [ ]  이미 지원중이거나 승인된 상태일 때 거절 모달 출력인데 현재 메세지가 
    동일함(”이미 지원중입니다.”) → 시간 남으면 바꿀예정 - yh

