### PR TITLE
Fix: 멤버 정보 실시간 연동 에러 해결

### DIFF
--- a/src/main/java/site/hesil/latteve_spring/domains/member/domain/Member.java
+++ b/src/main/java/site/hesil/latteve_spring/domains/member/domain/Member.java
@@ -29,7 +29,7 @@ import java.util.List;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-//@EntityListeners(MemberListener.class)
+@EntityListeners(MemberListener.class)
 public class Member extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/site/hesil/latteve_spring/global/rabbitMQ/consumer/MQConsumer.java
+++ b/src/main/java/site/hesil/latteve_spring/global/rabbitMQ/consumer/MQConsumer.java
@@ -49,6 +49,7 @@ public class MQConsumer {
         log.info("rabbit listener : project like 인덱싱");
         searchIndexingService.indexProjectLike(projectLike.getProjectLikeId().getProjectId());
     }
+
     @RabbitListener(queues = "#{@projectMemberUpdateQueue.name}")
     public void receiveUpdateProjectMemberMessage( AcceptedProjectMemberRequest projectMember) throws IOException {
         log.info("rabbit listener : projectMember_update_인덱싱 : member가 승인되어 currentMember에 들어감");
@@ -58,16 +59,12 @@ public class MQConsumer {
     @RabbitListener(queues = "#{@memberCreateQueue.name}")
     public void receiveCreateMemberMessage(Member member) throws IOException {
         log.info("rabbit listener : member_create 인덱싱");
-        searchIndexingService.indexMembersToOpenSearch();
+        searchIndexingService.indexMember(member);
 
     }
     @RabbitListener(queues = "#{@memberUpdateQueue.name}")
     public void receiveUpdateMessage(Member member) throws IOException {
-        searchIndexingService.indexMembersToOpenSearch(); // 업데이트 메시지 처리
+        searchIndexingService.indexMember(member); // 업데이트 메시지 처리
     }
 
-//    @RabbitListener(queues = "project.delete.queue")
-//    public void receiveDeleteMessage(Project project) {
-//        searchIndexingService.deleteProject(project.getId());  // 삭제 메시지 처리
-//    }
 }


### PR DESCRIPTION
## 📌 변경 사항
### AS-IS
- listener가  잘못 설정되어 있었음.

### TO-BE
멤버 가입 후 바로 검색 되도록 에러 해결


## 📌 테스트
- [ ] 테스트 코드
- [ ] API 테스트
